### PR TITLE
Genericization of Associativity and Commutativity Constructors

### DIFF
--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -141,6 +141,7 @@ import Data.Vec.Properties as VecProp
 import Data.Vec.Relation.Unary.Any as AnyVec
 import Data.Vec.Relation.Unary.All as AllVec
 import Data.List.Properties as ListProp
+import Data.List.Relation.Binary.Pointwise as PointwiseList
 \end{code}
 
 \chapter{Useful Abbreviations and Ilk}
@@ -2088,7 +2089,10 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
                     {y ∷ x ∷ []}
                     {refl}
                     refl
-                    {!!}
+                    (swapP refl refl (reflP PointwiseList.[]))
+        where
+        swapP = Data.List.Relation.Binary.Permutation.Setoid.swap
+        reflP = Data.List.Relation.Binary.Permutation.Setoid.refl
 
     ProductCommutes :
       {x y : ε} → main (Ap Product (x ∷ y ∷ [])) (Ap Product (y ∷ x ∷ []))
@@ -2098,7 +2102,10 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
                     {y ∷ x ∷ []}
                     {refl}
                     refl
-                    {!!}
+                    (swapP refl refl (reflP PointwiseList.[]))
+        where
+        swapP = Data.List.Relation.Binary.Permutation.Setoid.swap
+        reflP = Data.List.Relation.Binary.Permutation.Setoid.refl
 \end{code}
 
 \subsection{Completing the Equivalence Proof}

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2217,7 +2217,12 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
         main2 (repeatExceptional itx exceptionallyEvaluate x)
               (repeatExceptional ity exceptionallyEvaluate y) →
         main x y
+\end{code}
 
+\subsubsection{Some Useful Shorthands}
+A short summary is as follows: \AgdaFunction{ProductCommutes} and \AgdaFunction{SumCommutes} prove that commutative equality applies to multiplication and addition, respectively.
+
+\begin{code}
     SumCommutes :
       {x y : ε} → main (Ap Sum (x ∷ y ∷ [])) (Ap Sum (y ∷ x ∷ []))
     SumCommutes {x} {y} =

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2339,8 +2339,7 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
 A short summary is as follows: \AgdaFunction{ProductCommutes} and \AgdaFunction{SumCommutes} prove that commutative equality applies to multiplication and addition, respectively.  \AgdaFunction{SumIsAssociative} and \AgdaFunction{ProductIsAssociative} prove that associative equality applies to addition and multiplication, respectively.
 
 \begin{code}
-    SumCommutes :
-      {x y : ε} → main (Ap Sum (x ∷ y ∷ [])) (Ap Sum (y ∷ x ∷ []))
+    SumCommutes : {x y : ε} → main (Ap Sum (x ∷ y ∷ [])) (Ap Sum (y ∷ x ∷ []))
     SumCommutes {x} {y} =
       Commutativity {Sum}
                     {x ∷ y ∷ []}

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -119,6 +119,13 @@ open import Relation.Binary.PropositionalEquality.WithK
   using
     ( ≡-irrelevant
     )
+open import Data.List.Relation.Binary.Permutation.Setoid
+  renaming
+    ( _↭_ to IsSetoidPermutation
+    )
+  using
+    (
+    )
 import Data.List as List
 import Data.Nat.Coprimality as Coprimality
 import Data.Integer
@@ -2024,11 +2031,8 @@ A value of type \AgdaFunction{main2} \AgdaBound{x} \AgdaBound{y} exists if and o
 \subsubsection{Structural Equality's Implication of Algebraic Equality}
 According to \AgdaInductiveConstructor{EqualityImpliesAE}, two \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y} are structurally equal only if \AgdaBound{x} is algebraically equal to \AgdaBound{y}.
 
-\subsubsection{Sum Commutativity}
-Basically, according to \AgdaInductiveConstructor{SumCommutes}, \(a + b = b + a\) or, equivalently, if \(a = a\prime\) and \(b = b\prime\), then \(a + b = b\prime + a\prime\).
-
-\subsubsection{Product Commutativity}
-Basically, according to \AgdaInductiveConstructor{SumCommutes}, \(a \cdot b = b \cdot a\) or, equivalently, if \(a = a\prime\) and \(b = b\prime\), then \(a \cdot b = b\prime \cdot a\prime\).
+\subsubsection{Commutativity}
+Basically, according to \AgdaInductiveConstructor{Commutativity}, if \AgdaBound{a} is a permutation of \AgdaBound{b} and \AgdaBound{f} is commutative, then \AgdaBound{f} \AgdaBound{a} is algebraically equivalent to \AgdaBound{f} \AgdaBound{b}.
 
 \subsubsection{Sum Associativity}
 Basically, according to \AgdaInductiveConstructor{SumCommutes}, \(a + \left(b + c\right) = \left(a + b\right) + c\).
@@ -2050,10 +2054,15 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
 \begin{code}
     data main where
       EqualityImpliesAE : {e1 e2 : ε} → e1 ≡ e2 → main e1 e2
-      SumCommutes :
-        {x y : ε} → main (Ap Sum (x ∷ y ∷ [])) (Ap Sum (y ∷ x ∷ []))
-      ProductCommutes :
-        {x y : ε} → main (Ap Product (x ∷ y ∷ [])) (Ap Product (y ∷ x ∷ []))
+      Commutativity :
+        {f : F} →
+        {x y : Vec ε (arity f)} →
+        {eq2 : arity f ≡ 2} →
+        true ≡ isCommutative f eq2 →
+        IsSetoidPermutation (record {isEquivalence = isEquivalence})
+                            (Data.Vec.toList x)
+                            (Data.Vec.toList y) →
+        main (Ap f x) (Ap f y)
       SumIsAssociative :
         {x1 x2 x3 : ε} →
         main (Ap Sum (x1 ∷ [ Ap Sum (x2 ∷ [ x3 ]) ]))
@@ -2070,6 +2079,26 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
         main2 (repeatExceptional itx exceptionallyEvaluate x)
               (repeatExceptional ity exceptionallyEvaluate y) →
         main x y
+
+    SumCommutes :
+      {x y : ε} → main (Ap Sum (x ∷ y ∷ [])) (Ap Sum (y ∷ x ∷ []))
+    SumCommutes {x} {y} =
+      Commutativity {Sum}
+                    {x ∷ y ∷ []}
+                    {y ∷ x ∷ []}
+                    {refl}
+                    refl
+                    {!!}
+
+    ProductCommutes :
+      {x y : ε} → main (Ap Product (x ∷ y ∷ [])) (Ap Product (y ∷ x ∷ []))
+    ProductCommutes {x} {y} =
+      Commutativity {Product}
+                    {x ∷ y ∷ []}
+                    {y ∷ x ∷ []}
+                    {refl}
+                    refl
+                    {!!}
 \end{code}
 
 \subsection{Completing the Equivalence Proof}

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -1571,6 +1571,15 @@ The following statements hold:
   isCommutative (Compose g f eq) x = false
 \end{code}
 
+\section{The Associativity-Determining Function}
+
+\begin{code}
+  isAssociative : (f : F) → arity f ≡ 2 → Bool
+  isAssociative Sum refl = true
+  isAssociative Product refl = true
+  isAssociative f eq = false
+\end{code}
+
 \section{The Variable Substitution Function}\label{sec:varSubstM-def}
 \AgdaFunction{varSubstM} is the multi-variable substitution function.  In \AgdaFunction{varSubstM} \AgdaBound{l} \AgdaBound{e}, any variable in \AgdaBound{e} which also has an entry in \AgdaBound{l} will be replaced by the corresponding \AgdaDatatype{ε} entry in \AgdaBound{l}.  More formally, one can say that \AgdaFunction{varSubstM} \AgdaBound{l} \AgdaBound{e} is a derivative of \AgdaBound{e} such that for any given variable \AgdaBound{x} in \AgdaBound{e}, if a value \AgdaBound{i} exists such that \AgdaField{proj₁} \AgdaSymbol(\AgdaFunction{List.lookup} \AgdaBound{l} \AgdaBound{i}\AgdaSymbol) is \AgdaBound{x}, then \AgdaBound{x} is replaced by \AgdaField{proj₂} \AgdaSymbol(\AgdaFunction{List.lookup} \AgdaBound{l} \AgdaBound{i}\AgdaSymbol).
 
@@ -2170,11 +2179,8 @@ According to \AgdaInductiveConstructor{EqualityImpliesAE}, two \AgdaDatatype{ε}
 \subsubsection{Commutativity}
 Basically, according to \AgdaInductiveConstructor{Commutativity}, if \AgdaBound{a} is a permutation of \AgdaBound{b} and \AgdaBound{f} is commutative, then \AgdaBound{f} \AgdaBound{a} is algebraically equivalent to \AgdaBound{f} \AgdaBound{b}.
 
-\subsubsection{Sum Associativity}
-Basically, according to \AgdaInductiveConstructor{SumIsAssociative}, \(a + \left(b + c\right) = \left(a + b\right) + c\).
-
-\subsubsection{Product Associativity}
-Basically, according to \AgdaInductiveConstructor{ProductIsAssociative}, \(a \cdot \left(b \cdot c\right) = \left(a \cdot b\right) \cdot c\).
+\subsubsection{Associativity}
+Basically, according to \AgdaInductiveConstructor{Associativity}, if \AgdaBound{f} is associative and is of arity 2, then \(f\prime x \left(f y z\right) = f \left(f\prime x y\right) z\), where ``\(f'\)'' denotes the function which is represented by \AgdaBound{f}.
 
 \subsubsection{Composition}
 Thanks to \AgdaInductiveConstructor{Composition}, proving that \(g \left(f\ x\right)\) is \AgdaBound{c}-\gls{algEq} to \(\left(g \circ f\right)\ x\) is downright simple.
@@ -2202,14 +2208,13 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
                             (Data.Vec.toList x)
                             (Data.Vec.toList y) →
         main (Ap f x) (Ap f y)
-      SumIsAssociative :
-        {x1 x2 x3 : ε} →
-        main (Ap Sum (x1 ∷ [ Ap Sum (x2 ∷ [ x3 ]) ]))
-             (Ap Sum (Ap Sum (x1 ∷ [ x2 ]) ∷ [ x3 ]))
-      ProductIsAssociative :
-        {x1 x2 x3 : ε} →
-        main (Ap Product (x1 ∷ [ Ap Product (x2 ∷ [ x3 ]) ]))
-             (Ap Product (Ap Product (x1 ∷ [ x2 ]) ∷ [ x3 ]))
+      Associativity :
+        {f : F} →
+        {x y z : ε} →
+        {eq : arity f ≡ 2} →
+        true ≡ isAssociative f eq →
+        main (Ap f (cast (sym eq) (x ∷ [ Ap f (cast (sym eq) (y ∷ [ z ]))])))
+             (Ap f (cast (sym eq) (Ap f (cast (sym eq) (x ∷ [ y ])) ∷ [ z ])))
       Composition : {g f : F} →
                     {x : Vec ε (arity f)} →
                     (eq : arity g ≡ 1) →
@@ -2226,7 +2231,7 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
 \end{code}
 
 \subsubsection{Some Useful Shorthands}
-A short summary is as follows: \AgdaFunction{ProductCommutes} and \AgdaFunction{SumCommutes} prove that commutative equality applies to multiplication and addition, respectively.
+A short summary is as follows: \AgdaFunction{ProductCommutes} and \AgdaFunction{SumCommutes} prove that commutative equality applies to multiplication and addition, respectively.  \AgdaFunction{SumIsAssociative} and \AgdaFunction{ProductIsAssociative} prove that associative equality applies to addition and multiplication, respectively.
 
 \begin{code}
     SumCommutes :
@@ -2254,6 +2259,18 @@ A short summary is as follows: \AgdaFunction{ProductCommutes} and \AgdaFunction{
         where
         swapP = Data.List.Relation.Binary.Permutation.Setoid.swap
         reflP = Data.List.Relation.Binary.Permutation.Setoid.refl
+
+    SumIsAssociative :
+      {x1 x2 x3 : ε} →
+      main (Ap Sum (x1 ∷ [ Ap Sum (x2 ∷ [ x3 ]) ]))
+           (Ap Sum (Ap Sum (x1 ∷ [ x2 ]) ∷ [ x3 ]))
+    SumIsAssociative = Associativity refl
+
+    ProductIsAssociative :
+      {x1 x2 x3 : ε} →
+      main (Ap Product (x1 ∷ [ Ap Product (x2 ∷ [ x3 ]) ]))
+           (Ap Product (Ap Product (x1 ∷ [ x2 ]) ∷ [ x3 ]))
+    ProductIsAssociative = Associativity refl
 \end{code}
 
 \subsection{The Equivalence Proof}

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2197,10 +2197,10 @@ According to \AgdaInductiveConstructor{EqualityImpliesAE}, two \AgdaDatatype{ε}
 Basically, according to \AgdaInductiveConstructor{Commutativity}, if \AgdaBound{a} is a permutation of \AgdaBound{b} and \AgdaBound{f} is commutative, then \AgdaBound{f} \AgdaBound{a} is algebraically equivalent to \AgdaBound{f} \AgdaBound{b}.
 
 \subsubsection{Sum Associativity}
-Basically, according to \AgdaInductiveConstructor{SumCommutes}, \(a + \left(b + c\right) = \left(a + b\right) + c\).
+Basically, according to \AgdaInductiveConstructor{SumIsAssociative}, \(a + \left(b + c\right) = \left(a + b\right) + c\).
 
 \subsubsection{Product Associativity}
-Basically, according to \AgdaInductiveConstructor{ProductCommutes}, \(a \cdot \left(b \cdot c\right) = \left(a \cdot b\right) \cdot c\).
+Basically, according to \AgdaInductiveConstructor{ProductIsAssociative}, \(a \cdot \left(b \cdot c\right) = \left(a \cdot b\right) \cdot c\).
 
 \subsubsection{Symmetry}
 Basically, according to \AgdaInductiveConstructor{Symmetry}, if \(a = b\), then \(b = a\).


### PR DESCRIPTION
AlgebraicEquality's constructors for associativity and commutativity no longer apply only to addition and multiplication.

Well, right now, the constructors only apply to addition and multiplication, but the constructors *could* apply to other functions, too, with no modification.