### PR TITLE
Rule Names

### DIFF
--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -1140,6 +1140,7 @@ For the purposes of this document, a verified computer algebra system is the com
  \item a proof which indicates that \(f x\) is equal to \(\lim_{y \rightarrow x} \left(f y\right)\) if \(f x\) is non-bogus,
  \item a proof of L'H\^opital's rule,
  \item a proof of the equality between \(x\) and \(- \left(- x\right)\),
+ \item a proof which indicates that an evaluated constant is also a constant,
  \item a proof which indicates that if \AgdaBound{m} is less than \AgdaBound{n}, then \AgdaField{fromℕ} \AgdaBound{m} is less than \AgdaField{fromℕ} \AgdaBound{n}, and
  \item a proof of the correctness of the factoring function.
 \end{itemize}
@@ -1151,6 +1152,11 @@ A good CAS represents the complex numbers, whose equality relation is an equival
 
 \subsection{The Structural-Equivalence-to-Algebraic-Equality Function}
 Also, in a good CAS, two expressions \(e_1\) and \(e_2\) are represented in the same way only if \(e_1\) is algebraically equal to \(e_2\).  This fact is represented through the use of \AgdaField{structural-equality-implies-definite-equality}.
+
+\section{General Proofs regarding Constants}
+
+\subsection{The Constant Evaluation Proof}
+\AgdaField{VCAS.evaluated-constant-is-a-constant} \AgdaBound{v} proves that the \AgdaBound{v} CAS evaluates any constant to a constant.
 
 \section{Variable Correctness Proofs}
 
@@ -1502,6 +1508,12 @@ record VCAS {a : Level} {ε : Set a} (Cas : CAS ε) : Set a where
       (l : List.List ε) →
       e ≈ List.foldr _*_ (fromℕ 1) l →
       l ∈ factor e
+
+    evaluated-constant-is-a-constant :
+      (e : ε) →
+      (count : ℕ) →
+      IsConstant e →
+      ((Exceptional ε → Set) ∋ λ {(inj₂ x) → IsConstant x ; (inj₁ exc) → ⊤}) (rEvaluate count e)
 
     natural-less-than : (m n : ℕ) → m Data.Nat.< n → fromℕ m < fromℕ n
 \end{code}
@@ -3113,6 +3125,7 @@ CasanovaFly-Verified = record
   ; natural-less-than = {!!}
   ; factor-input-is-product-of-output = {!!}
   ; factor-list-contains-all-factor-lists = {!!}
+  ; evaluated-constant-is-a-constant = {!!}
   }
   where
   open CAS CasanovaFly-Base

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2207,30 +2207,30 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
                        (decToMaybe (structuralEqualityOnε b c))
 
       module sumCommCheck where
-        applyEquality : {x y x' y' : ε} →
-                        x ≡ x' →
-                        y ≡ y' →
-                        AlgebraicEquality (Ap Sum (x ∷ y ∷ []))
-                                          (Ap Sum (y' ∷ x' ∷ []))
-        applyEquality refl refl = AlgebraicEquality.SumCommutes
+        applyEqualities : {x y x' y' : ε} →
+                          x ≡ x' →
+                          y ≡ y' →
+                          AlgebraicEquality (Ap Sum (x ∷ y ∷ []))
+                                            (Ap Sum (y' ∷ x' ∷ []))
+        applyEqualities refl refl = AlgebraicEquality.SumCommutes
 
         main : Check
         main {Ap Sum (a ∷ b ∷ [])} {Ap Sum (c ∷ d ∷ [])} =
-          Data.Maybe.map (uncurry applyEquality) bi-eq
+          Data.Maybe.map (uncurry applyEqualities) bi-eq
         main = nothing
 
       module prodCommCheck where
-        applyEquality :
+        applyEqualities :
           {x y x' y' : ε} →
           x ≡ x' →
           y ≡ y' →
           AlgebraicEquality (Ap Product (x ∷ y ∷ []))
                             (Ap Product (y' ∷ x' ∷ []))
-        applyEquality refl refl = AlgebraicEquality.ProductCommutes
+        applyEqualities refl refl = AlgebraicEquality.ProductCommutes
 
         main : Check
         main {Ap Product (a ∷ b ∷ [])} {Ap Product (c ∷ d ∷ [])} =
-          Data.Maybe.map (uncurry applyEquality) bi-eq
+          Data.Maybe.map (uncurry applyEqualities) bi-eq
         main = nothing
 
       sumAssCheck : Check

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -1492,8 +1492,8 @@ record VCAS {a : Level} {ε : Set a} (Cas : CAS ε) : Set a where
     tangent-is-bogus-at-quarter-tau :
       (n : ℕ) →
       let product = τ * (fromℕ n + (fromℕ 1 / fromℕ 4)) in
-      _×_ (bogus-at-some-iteration product)
-          (bogus-at-some-iteration (negation product))
+      _×_ (bogus-at-some-iteration (tan product))
+          (bogus-at-some-iteration (tan (negation product)))
 
     factor-input-is-product-of-output :
       (e : ε) →

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -1119,8 +1119,7 @@ For the purposes of this document, a verified computer algebra system is the com
  \item a proof of commutativity of multiplication,
  \item a proof of associativity of addition,
  \item a proof of the inverse relationship between multiplication and division,
- \item a proof of the bogosity of \(0^0\),
- \item a proof of the bogosity of \(0^e\), where \(e < 0\),
+ \item a proof of the bogosity of \(0^e\), where \(e \leq 0\),
  \item a proof which indicates that \(\lim_{x \rightarrow n} e\) is algebraically equal to \(n\) if \(x\) is not referenced in \(e\),
  \item a proof of the algebraic equality between \(\left(\lambda\ x \rightarrow x\right)\ e\) and \(e\),
  \item a proof which indicates that \(\left(\lambda\ x \rightarrow y\right)\ e\) is algebraically equal to \(y\) if \(x\) is not referenced in \(y\),
@@ -1195,11 +1194,8 @@ That the quotient of any given number and zero is bogus, i.e., undefined, is wel
 
 \section{Exponentiation Correctness Proofs}
 
-\subsection{The Proof of the Bogosity of \(0^0\)}
-\AgdaField{VCAS.0\textasciicircum{}0-is-bogus} \AgdaBound{c} indicates that in the \AgdaBound{c} CAS, \(0^0\) is bogus at some iteration count.
-
 \subsection{The Proof of the Bogosity of \(0^e\), where \(e < 0\)}
-\AgdaField{VCAS.0\textasciicircum{}-n-is-bogus} \AgdaBound{v} indicates that for all relevant expressions \(e\), if \(e < 0\), then the CAS will eventually determine that \(0^e\) is bogus.
+\AgdaField{VCAS.0\textasciicircum{}-n-is-bogus} \AgdaBound{v} indicates that for all relevant expressions \(e\), if \(e \leq 0\), then the \AgdaBound{v} CAS will eventually determine that \(0^e\) is bogus.
 
 \section{Limit Correctness Proofs}
 
@@ -1365,8 +1361,7 @@ record VCAS {a : Level} {ε : Set a} (Cas : CAS ε) : Set a where
       (e1 e2 : ε) →
       IsNotBogus (e2 / e1) →
       equal-at-some-iteration e2 (e1 * (e2 / e1))
-    0^0-is-bogus : IsBogus (fromℕ 0 ^ fromℕ 0)
-    0^-n-is-bogus : (e : ε) → e < fromℕ 0 → IsBogus (fromℕ 0 ^ e)
+    0^-n-is-bogus : (e : ε) → e ≤ fromℕ 0 → IsBogus (fromℕ 0 ^ e)
     repeated-negation-cancelation :
       (e : ε) → equal-at-some-iteration e (negation (negation e))
     simple-lambda-substitution-works :
@@ -3091,7 +3086,6 @@ CasanovaFly-Verified = record
   ; product-is-commutative = {!!}
   ; sum-is-associative = {!!}
   ; product-of-quotient-is-same = {!!}
-  ; 0^0-is-bogus = 1 , _ , refl
   ; 0^-n-is-bogus = {!!}
   ; repeated-negation-cancelation =
     let open AlgebraicEquality in

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2390,8 +2390,8 @@ The bogus results may or may not indicate that the input expression is bogus.
 \AgdaFunction{rules} is the list of evaluation rules which are used by \AgdaFunction{main}, i.e., \AgdaFunction{exceptionallyEvaluate}.
 
 \begin{code}
-    rules =
-        record
+    rules = List.concat (List.map ruleWithRecurse (Data.Vec.toList
+      ( record
           { name = "DOUBLE NEGATION"
           ; function =
             λ { (Ap Negate (Ap Negate (x ∷ []) ∷ [])) → valid x
@@ -2662,15 +2662,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           { name = "CHAIN RULE FOR DERIVATIVES"
           ; function = basicDerivativeChainRuleFunction
           }
-      -- The naming of the following function could probably be improved.
-      -- Ideally, the function's name would be the name of the applied
-      -- simplification step, not just a simple "SIMPLIFY".
-      ∷ record
-          { name = "SIMPLIFY"
-          ; function = λ { (Ap f x) → [_,_] bust (valid ∘ Ap f) (updateFirst x)
-                         ; _ → nothing}
-          }
-      ∷ []
+      ∷ [])))
       where
       bust = just ∘ inj₁
       valid = just ∘ inj₂
@@ -2684,6 +2676,15 @@ The bogus results may or may not indicate that the input expression is bogus.
           (main x)
       ... | yes eq = [_,_]′ inj₁ (λ xs → inj₂ (x ∷ xs)) (updateFirst xs)
       ... | no neq = [_,_]′ inj₁ (λ x → inj₂ (x ∷ xs)) (main x)
+      recurseWithRule : EvaluationRule → EvaluationRule
+      recurseWithRule rule = record
+        { name = EvaluationRule.name rule
+        ; function =
+          λ { (Ap f x) → [_,_] bust (valid ∘ Ap f) (updateFirst x)
+            ; _ → nothing}
+        }
+      ruleWithRecurse : EvaluationRule → List.List EvaluationRule
+      ruleWithRecurse rule = rule List.∷ List.[ recurseWithRule rule ]
       freeDerivativesFromPoints : ε → Maybe (Exceptional ε)
       freeDerivativesFromPoints =
         λ { (Ap (Derivative n) (x ∷ [])) →
@@ -2713,7 +2714,7 @@ The bogus results may or may not indicate that the input expression is bogus.
     {-# TERMINATING #-}
     main e = fromMaybe (inj₂ e)
            $ List.head ∘ List.mapMaybe (λ rule → EvaluationRule.function rule e)
-           $ Data.Vec.toList rules
+           $ rules
 
   {-# TERMINATING #-}
 \end{code}
@@ -3169,7 +3170,7 @@ CasanovaFly-Verified = record
   ; product-is-commutative = {!!}
   ; sum-is-associative = {!!}
   ; product-of-quotient-is-same = {!!}
-  ; 0^0-is-bogus = 1 , _ , refl
+  ; 0^0-is-bogus = 1 , _ , {!!}
   ; 0^-n-is-bogus = {!!}
   ; repeated-negation-cancelation =
     let open AlgebraicEquality in

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2201,6 +2201,11 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
     module directCheck where
       Check = {x y : ε} → Maybe (AlgebraicEquality x y)
 
+      bi-eq : {a b c d : ε} → Maybe ((a ≡ d) × (b ≡ c))
+      bi-eq {a} {b} {c} {d} =
+        Data.Maybe.zip (decToMaybe (structuralEqualityOnε a d))
+                       (decToMaybe (structuralEqualityOnε b c))
+
       module sumCommCheck where
         applyEquality : {x y x' y' : ε} →
                         x ≡ x' →
@@ -2209,14 +2214,9 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
                                           (Ap Sum (y' ∷ x' ∷ []))
         applyEquality refl refl = AlgebraicEquality.SumCommutes
 
-        eq : {a b c d : ε} → Maybe ((a ≡ d) × (b ≡ c))
-        eq {a} {b} {c} {d} =
-          Data.Maybe.zip (decToMaybe (structuralEqualityOnε a d))
-                         (decToMaybe (structuralEqualityOnε b c))
-
         main : Check
         main {Ap Sum (a ∷ b ∷ [])} {Ap Sum (c ∷ d ∷ [])} =
-          Data.Maybe.map (uncurry applyEquality) eq
+          Data.Maybe.map (uncurry applyEquality) bi-eq
         main = nothing
 
       module prodCommCheck where
@@ -2230,7 +2230,7 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
 
         main : Check
         main {Ap Product (a ∷ b ∷ [])} {Ap Product (c ∷ d ∷ [])} =
-          Data.Maybe.map (uncurry applyEquality) sumCommCheck.eq
+          Data.Maybe.map (uncurry applyEquality) bi-eq
         main = nothing
 
       sumAssCheck : Check

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2238,6 +2238,13 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
         Data.Maybe.zip (decToMaybe (structuralEqualityOnε a d))
                        (decToMaybe (structuralEqualityOnε b c))
 
+      tri-eq : {a b c x y z : ε} →
+               Maybe ((a ≡ x) × (b ≡ y) × (c ≡ z))
+      tri-eq {a} {b} {c} {x} {y} {z} =
+        Data.Maybe.zip (decToMaybe (structuralEqualityOnε a x))
+                       (Data.Maybe.zip (decToMaybe (structuralEqualityOnε b y))
+                                       (decToMaybe (structuralEqualityOnε c z)))
+
       module sumCommCheck where
         applyEqualities : {x y x' y' : ε} →
                           x ≡ x' →
@@ -2265,8 +2272,25 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
           Data.Maybe.map (uncurry applyEqualities) bi-eq
         main = nothing
 
-      sumAssCheck : Check
-      sumAssCheck = {!!}
+      module sumAssCheck where
+        applyEqualities :
+          {a b c a' b' c' : ε} →
+          a ≡ a' →
+          b ≡ b' →
+          c ≡ c' →
+          AlgebraicEquality (Ap Sum (a ∷ Ap Sum (b ∷ c ∷ []) ∷ []))
+                            (Ap Sum (Ap Sum (a' ∷ b' ∷ []) ∷ c' ∷ []))
+        applyEqualities refl refl refl = AlgebraicEquality.SumIsAssociative
+
+        main : Check
+        main {Ap Sum (a ∷ Ap Sum (b ∷ c ∷ []) ∷ [])}
+             {Ap Sum (Ap Sum (x ∷ y ∷ []) ∷ z ∷ [])} =
+             Data.Maybe.map (λ (a , b , c) → applyEqualities a b c)
+                            (tri-eq {a} {b} {c} {x} {y} {z})
+        main e1@{Ap Sum (Ap Sum (x ∷ y ∷ []) ∷ z ∷ [])}
+             e2@{Ap Sum (a ∷ Ap Sum (b ∷ c ∷ []) ∷ [])} =
+               Data.Maybe.map AlgebraicEquality.Symmetry (main {e2} {e1})
+        main = nothing
 
       prodAssCheck : Check
       prodAssCheck = {!!}
@@ -2274,7 +2298,7 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
       main : Check
       main =   sumCommCheck.main
            <∣> prodCommCheck.main
-           <∣> sumAssCheck
+           <∣> sumAssCheck.main
            <∣> prodAssCheck
 
     module complexCheck where

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2060,8 +2060,8 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
              (Ap Sum (Ap Sum (x1 ∷ [ x2 ]) ∷ [ x3 ]))
       ProductIsAssociative :
         {x1 x2 x3 : ε} →
-        main (Ap Sum (x1 ∷ [ Ap Sum (x2 ∷ [ x3 ]) ]))
-             (Ap Sum (Ap Sum (x1 ∷ [ x2 ]) ∷ [ x3 ]))
+        main (Ap Product (x1 ∷ [ Ap Product (x2 ∷ [ x3 ]) ]))
+             (Ap Product (Ap Product (x1 ∷ [ x2 ]) ∷ [ x3 ]))
       Symmetry : {x y : ε} → main x y → main y x
       Transitivity : {x y z : ε} → main x y → main y z → main x z
       Eventuality :

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -1136,7 +1136,7 @@ For the purposes of this document, a verified computer algebra system is the com
  \item a proof of the equality between \(\lim_{x \rightarrow y} \left(a + b\right)\) and \(\left(\lim_{x \rightarrow y} a\right) + \lim_{x \rightarrow y} b\),
  \item a proof of the equality between \(\lim_{x \rightarrow y} \left(- x\right)\) and \(- \lim_{x \rightarrow y} x\),
  \item a proof of the equality between \(\lim_{x \rightarrow y} \left(a \cdot b\right)\) and \(\left(\lim_{x \rightarrow y} a\right) \cdot \lim_{x \rightarrow y} b\),
- \item a proof which indicates that \(f x\) is equal to \(\lim_{y \rightarrow x} \left(f y\right)\) if \(f x\) is non-bogus,
+ \item a proof which indicates that \(f\ x\) is equal to \(\lim_{y \rightarrow x} \left(f\ y\right)\) if \(f\ x\) is non-bogus,
  \item a proof of L'H\^opital's rule,
  \item a proof of the equality between \(x\) and \(- \left(- x\right)\),
  \item a proof which indicates that an evaluated constant is also a constant,

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2362,158 +2362,315 @@ A bit informally, one can say that \AgdaFunction{composition-equality} proves th
 
 \begin{code}
   module exceptionallyEvaluate where
-    main : ε → Exceptional ε
+\end{code}
 
-    functions =
-      ( (λ { (Ap Negate (Ap Negate (x ∷ []) ∷ [])) → valid x
-           ; _ → nothing})
-      ∷ (λ { (Ap Negate (NumberRat x ∷ [])) → valid (NumberRat (ℚ.0ℚ ℚ.- x))
-           ; _ → nothing})
-      ∷ (λ { (Ap Sum (NumberNatP 0 c ∷ x ∷ [])) → valid x
-           ; _ → nothing})
-      ∷ (λ { (Ap Sum (NumberRat x ∷ NumberRat y ∷ [])) →
-             valid (NumberRat (x ℚ.+ y))
-           ; _ → nothing})
-      ∷ (λ { (Ap Product (NumberRat x ∷ NumberRat y ∷ [])) →
-             valid (NumberRat (x ℚ.* y))
-           ; _ → nothing})
-      ∷ (λ { (Ap Exponent (NumberNatP x c1 ∷ NumberNatP y c2 ∷ [])) →
-             if (x Data.Nat.≡ᵇ 0) ∧ (y Data.Nat.≡ᵇ 0)
-               then bust "0^0 is undefined!"
-               else valid (NumberNat (x Data.Nat.^ y))
-           ; _ → nothing})
-      ∷ (λ { (Ap Exponent (NumberNatP 0 coprime ∷ NumberRat y ∷ [])) →
-             if y ℚ.≤ᵇ ℚ.0ℚ
-                then bust "\\(0^x\\) is undefined for non-positive \\(x\\)!"
-                else nothing
-           ; _ → nothing})
+\subsection{The Type of the Main Function}
+\AgdaFunction{main} will eventually become \AgdaFunction{exceptionallyEvaluate}.
+
+\begin{code}
+    main : ε → Exceptional ε
+\end{code}
+
+\subsection{The Evaluation Rule Type}
+\AgdaRecord{EvaluationRule} is the type of evaluation rules, i.e., computation strategies, which are used by \AgdaFunction{exceptionallyEvaluate}.  For a given \AgdaRecord{EvaluationRule} value \AgdaBound{r}, \AgdaField{EvaluationRule.name} \AgdaBound{r} and \AgdaField{EvaluationRule.function} \AgdaBound{r} are the name of \AgdaBound{r} and the method of applying \AgdaBound{r}, respectively.
+
+\subsubsection{The Function Field}
+For the function field, \AgdaInductiveConstructor{just} \AgdaOperator{\AgdaFunction{∘}} \AgdaInductiveConstructor{inj₂} values, \AgdaInductiveConstructor{just} \AgdaOperator{\AgdaFunction{∘}} \AgdaInductiveConstructor{inj₁} values, and \AgdaInductiveConstructor{nothing} values are the results of successful application, indicators of bogus results, and indicators of nonapplicability, respectively.
+
+The bogus results may or may not indicate that the input expression is bogus.
+
+\begin{code}
+    record EvaluationRule : Set where
+      field
+        name : String
+        function : ε → Maybe (Exceptional ε)
+\end{code}
+
+\subsection{The Evaluation Rules}
+\AgdaFunction{rules} is the list of evaluation rules which are used by \AgdaFunction{main}, i.e., \AgdaFunction{exceptionallyEvaluate}.
+
+\begin{code}
+    rules =
+        record
+          { name = "DOUBLE NEGATION"
+          ; function =
+            λ { (Ap Negate (Ap Negate (x ∷ []) ∷ [])) → valid x
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "RATIONAL NEGATION"
+          ; function =
+            λ { (Ap Negate (NumberRat x ∷ [])) → valid (NumberRat (ℚ.0ℚ ℚ.- x))
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "0 + x = x"
+          ; function =
+            λ { (Ap Sum (NumberNatP 0 c ∷ x ∷ [])) → valid x
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "RATIONAL SUM"
+          ; function =
+            λ { (Ap Sum (NumberRat x ∷ NumberRat y ∷ [])) →
+                valid (NumberRat (x ℚ.+ y))
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "RATIONAL PRODUCT"
+          ; function =
+            λ { (Ap Product (NumberRat x ∷ NumberRat y ∷ [])) →
+                valid (NumberRat (x ℚ.* y))
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "NATURAL EXPONENT"
+          ; function =
+            λ { (Ap Exponent (NumberNatP x c1 ∷ NumberNatP y c2 ∷ [])) →
+                if (x Data.Nat.≡ᵇ 0) ∧ (y Data.Nat.≡ᵇ 0)
+                  then bust "0^0 is undefined!"
+                  else valid (NumberNat (x Data.Nat.^ y))
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "RATIONAL EXPONENT OF NATURAL"
+          ; function =
+            λ { (Ap Exponent (NumberNatP 0 coprime ∷ NumberRat y ∷ [])) →
+                if y ℚ.≤ᵇ ℚ.0ℚ
+                   then bust "\\(0^x\\) is undefined for non-positive \\(x\\)!"
+                   else nothing
+              ; _ → nothing}
+          }
       -- The following "x^0" evaluation rule is a bit dubious; this rule
       -- indicates that Variable x ^ fromℕ 0 is algebraically equal to
       -- fromℕ 1.  However, Variable x *could* feasibly be defined as
       -- being equal to fromℕ 0.
       -- The current behavior parallels Maxima, though.
-      ∷ (λ { (Ap Exponent (x ∷ NumberNatP 0 c ∷ [])) → valid (NumberNat 1)
-           ; _ → nothing})
+      ∷ record
+          { name = "0 ^ x = 1"
+          ; function =
+            λ { (Ap Exponent (x ∷ NumberNatP 0 c ∷ [])) → valid (NumberNat 1)
+              ; _ → nothing}
+          }
       -- The following "0^x" evaluation rule, like the "x^0" rule, is
       -- kind of dubious.  This rule, too, mirrors the behavior of
       -- Maxima, though.
-      ∷ (λ { (Ap Exponent ((NumberNatP 0 c) ∷ e ∷ [])) →
-             let eq2 = Data.Sum.Properties.≡-dec Data.String._≟_
-                                                 structuralEqualityOnε in
-             -- The following check ensures that expressions like
-             -- Ap Exponent (NumberRat ℚ.0ℚ ∷ [ NumberNat 0 ])
-             -- are not wrongly evaluated to inj₂ (NumberNat 0).
-             if isYes (eq2 (inj₂ e) (main e))
-                then valid (NumberNat 0)
-                else [_,_] bust
-                           (λ x → valid (Ap Exponent ((NumberNat 0) ∷ [ x ])))
-                           (main e)
-           ; _ → nothing})
-      ∷ (λ { (Ap Exponent (x ∷ NumberNatP 1 c ∷ [])) → valid x
-           ; _ → nothing})
+      ∷ record
+          { name = "0 ^ x"
+          ; function =
+            λ { (Ap Exponent ((NumberNatP 0 c) ∷ e ∷ [])) →
+                 let eq2 = Data.Sum.Properties.≡-dec Data.String._≟_
+                                                     structuralEqualityOnε in
+                 -- The following check ensures that expressions like
+                 -- Ap Exponent (NumberRat ℚ.0ℚ ∷ [ NumberNat 0 ])
+                 -- are not wrongly evaluated to inj₂ (NumberNat 0).
+                 if isYes (eq2 (inj₂ e) (main e))
+                    then valid (NumberNat 0)
+                    else [_,_] bust
+                               (λ x → valid (Ap Exponent ((NumberNat 0) ∷ [ x ])))
+                               (main e)
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "x ^ 1 = x"
+          ; function =
+            λ { (Ap Exponent (x ∷ NumberNatP 1 c ∷ [])) → valid x
+              ; _ → nothing}
+          }
       -- The following evaluation rule prevents becoming stuck in a
       -- derivative evaluation loop.
-      ∷ (λ { (Ap (Lambda (n1 List.∷ List.[])) (Ap (Derivative n2) e1 ∷ e2 ∷ [])) →
-             [_,_]′ bust
-                    (λ derivative → valid (Ap (Lambda List.[ n1 ])
-                                              (derivative ∷ [ e2 ])))
-                    (main (Ap (Derivative n2) e1))
-           ; _ → nothing})
+      ∷ record
+          { name = "DERIVATIVE LOOP PREVENTION"
+          ; function =
+            λ { (Ap (Lambda (n1 List.∷ List.[])) (Ap (Derivative n2) e1 ∷ e2 ∷ [])) →
+                [_,_]′ bust
+                       (λ derivative → valid (Ap (Lambda List.[ n1 ])
+                                                 (derivative ∷ [ e2 ])))
+                       (main (Ap (Derivative n2) e1))
+              ; _ → nothing}
+          }
       -- The following evaluation rule is *also* kind of dubious, but,
       -- again, the behavior is like the behavior of Maxima.
-      ∷ (λ { (Ap (Derivative v1) (Variable v2 ∷ [])) →
-             if v1 Data.String.== v2
-               then valid (NumberNat 1)
-               else valid (NumberNat 0)
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (NumberRat x ∷ [])) →
-             valid (NumberNat 0)
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (Ap Negate x ∷ [])) →
-             valid (Ap Negate [ Ap (Derivative v1) x ])
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (Ap Sum (x ∷ y ∷ []) ∷ [])) →
-             valid (Ap Sum ( Ap (Derivative v1) [ x ]
-                           ∷ [ Ap (Derivative v1) [ y ] ]))
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (Ap Product (x ∷ y ∷ []) ∷ [])) →
-             valid (Ap Sum
-                       ( Ap Product (Ap (Derivative v1) [ x ] ∷ [ y ])
-                       ∷ [ Ap Product (Ap (Derivative v1) [ y ] ∷ [ x ])]))
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (Ap Sin (Variable v2 ∷ []) ∷ [])) →
-             if v1 Data.String.== v2
-               then valid (Ap Cos [ Variable v1 ])
-               else nothing
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (Ap Cos (Variable v2 ∷ []) ∷ [])) →
-             if v1 Data.String.== v2
-               then valid (Ap Negate [ Ap Sin [ Variable v1 ] ])
-               else nothing
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (Ap Tan (Variable v2 ∷ []) ∷ [])) →
-             if v1 Data.String.== v2
-               then valid (Ap Exponent ( Ap Sec [ Variable v1 ] ∷ [ NumberNat 2 ]))
-               else nothing
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (Ap Csc (Variable v2 ∷ []) ∷ [])) →
-             if v1 Data.String.== v2
-               then valid (Ap Product
-                              ( Ap Csc [ Variable v1 ]
-                              ∷ [ Ap Negate [ Ap Cot [ Variable v1 ] ] ]))
-               else nothing
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (Ap Sec (Variable v2 ∷ []) ∷ [])) →
-             if v1 Data.String.== v2
-               then valid (Ap Product
-                              ( Ap Sec [ Variable v1 ]
-                              ∷ [ Ap Tan [ Variable v1 ] ]))
-               else nothing
-           ; _ → nothing})
-      ∷ (λ { (Ap (Derivative v1) (Ap Cot (Variable v2 ∷ []) ∷ [])) →
-             if v1 Data.String.== v2
-               then valid (Ap Negate
-                              [ Ap Exponent
-                                   ( Ap Csc [ Variable v1 ]
-                                   ∷ [ NumberNat 2 ]) ])
-               else nothing
-           ; _ → nothing})
-      ∷ (λ { (Ap (Limit n1) (b ∷ Variable n2 ∷ [])) →
-             if n1 Data.String.== n2
-                then valid b
-                else nothing
-           ; _ → nothing})
-      ∷ (λ { (Ap (Limit n) (b ∷ e ∷ [])) →
-             if isYes (IsConstant? e) then valid e else nothing
-           ; _ → nothing})
-      ∷ (λ { (Ap (Limit n) (b ∷ (Ap Sum (x ∷ y ∷ [])) ∷ [])) →
-             valid (Ap Sum (Ap (Limit n) (b ∷ [ x ]) ∷ [ Ap (Limit n) (b ∷ [ y ]) ]))
-           ; _ → nothing})
-      ∷ (λ { (Ap (Limit n) (b ∷ (Ap Negate (x ∷ [])) ∷ [])) →
-             valid (Ap Negate [ Ap (Limit n) (b ∷ [ x ])])
-           ; _ → nothing})
-      ∷ (λ { (Ap (Limit n) (b ∷ Quotient x y coprime ∷ [])) →
-             valid (Quotient (Ap (Limit n) (b ∷ [ x ]))
-                             (Ap (Limit n) (b ∷ [ y ]))
-                             coprime)
-           ; _ → nothing})
-      ∷ (λ { (Ap (Limit n) (b ∷ Ap Product (x ∷ y ∷ []) ∷ [])) →
-             valid (Ap Product (Ap (Limit n) (b ∷ [ x ]) ∷ [ Ap (Limit n) (b ∷ [ y ])]))
-           ; _ → nothing})
-      ∷ (λ { (Ap (Limit n1) (c ∷ Ap Exponent (Variable n2 ∷ NumberNatP x copr ∷ []) ∷ [])) →
-             if (n1 Data.String.== n2) ∧ (0 Data.Nat.<ᵇ x)
-                then valid (Ap Exponent (c ∷ [ NumberNat x ]))
-                else nothing
-           ; _ → nothing})
-      ∷ (λ { (Ap (Lambda names) (body ∷ expressions)) →
-             valid (varSubstM (List.zip names (Data.Vec.toList expressions)) body)
-           ; _ → nothing})
-      ∷ freeDerivativesFromPoints
-      ∷ basicDerivativeChainRuleFunction
-      ∷ (λ { (Ap f x) → [_,_] bust (valid ∘ Ap f) (updateFirst x)
-           ; _ → nothing})
+      ∷ record
+          { name = "DERIVATIVE OF X W.R.T. X IS 1"
+          ; function =
+            λ { (Ap (Derivative v1) (Variable v2 ∷ [])) →
+                if v1 Data.String.== v2
+                  then valid (NumberNat 1)
+                  else valid (NumberNat 0)
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE OF RATIONAL IS 0"
+          ; function =
+            λ { (Ap (Derivative v1) (NumberRat x ∷ [])) →
+                valid (NumberNat 0)
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE OF NEGATIVE IS NEGATIVE DERIVATIVE"
+          ; function =
+            λ { (Ap (Derivative v1) (Ap Negate x ∷ [])) →
+                valid (Ap Negate [ Ap (Derivative v1) x ])
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE OF SUM IS SUM OF DERIVATIVES"
+          ; function =
+            λ { (Ap (Derivative v1) (Ap Sum (x ∷ y ∷ []) ∷ [])) →
+                valid (Ap Sum ( Ap (Derivative v1) [ x ]
+                              ∷ [ Ap (Derivative v1) [ y ] ]))
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "PRODUCT RULE FOR DERIVATIVES"
+          ; function =
+            λ { (Ap (Derivative v1) (Ap Product (x ∷ y ∷ []) ∷ [])) →
+                valid (Ap Sum
+                          ( Ap Product (Ap (Derivative v1) [ x ] ∷ [ y ])
+                          ∷ [ Ap Product (Ap (Derivative v1) [ y ] ∷ [ x ])]))
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE OF SINE"
+          ; function =
+            λ { (Ap (Derivative v1) (Ap Sin (Variable v2 ∷ []) ∷ [])) →
+                if v1 Data.String.== v2
+                  then valid (Ap Cos [ Variable v1 ])
+                  else nothing
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE OF COSINE"
+          ; function =
+            λ { (Ap (Derivative v1) (Ap Cos (Variable v2 ∷ []) ∷ [])) →
+                if v1 Data.String.== v2
+                  then valid (Ap Negate [ Ap Sin [ Variable v1 ] ])
+                  else nothing
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE OF TANGENT"
+          ; function =
+             λ { (Ap (Derivative v1) (Ap Tan (Variable v2 ∷ []) ∷ [])) →
+                 if v1 Data.String.== v2
+                   then valid (Ap Exponent ( Ap Sec [ Variable v1 ] ∷ [ NumberNat 2 ]))
+                   else nothing
+               ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE OF COSECANT"
+          ; function =
+            λ { (Ap (Derivative v1) (Ap Csc (Variable v2 ∷ []) ∷ [])) →
+                if v1 Data.String.== v2
+                  then valid (Ap Product
+                                 ( Ap Csc [ Variable v1 ]
+                                 ∷ [ Ap Negate [ Ap Cot [ Variable v1 ] ] ]))
+                  else nothing
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE OF SECANT"
+          ; function =
+            λ { (Ap (Derivative v1) (Ap Sec (Variable v2 ∷ []) ∷ [])) →
+                if v1 Data.String.== v2
+                  then valid (Ap Product
+                                 ( Ap Sec [ Variable v1 ]
+                                 ∷ [ Ap Tan [ Variable v1 ] ]))
+                  else nothing
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE OF COTANGENT"
+          ; function =
+            λ { (Ap (Derivative v1) (Ap Cot (Variable v2 ∷ []) ∷ [])) →
+                if v1 Data.String.== v2
+                  then valid (Ap Negate
+                                 [ Ap Exponent
+                                      ( Ap Csc [ Variable v1 ]
+                                      ∷ [ NumberNat 2 ]) ])
+                  else nothing
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "LIMIT OF SAME VARIABLE"
+          ; function =
+            λ { (Ap (Limit n1) (b ∷ Variable n2 ∷ [])) →
+                if n1 Data.String.== n2
+                   then valid b
+                   else nothing
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "LIMIT OF CONSTANT IS SAME CONSTANT"
+          ; function =
+            λ { (Ap (Limit n) (b ∷ e ∷ [])) →
+                if isYes (IsConstant? e) then valid e else nothing
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "LIMIT OF SUM IS SUM OF LIMITS"
+          ; function =
+            λ { (Ap (Limit n) (b ∷ (Ap Sum (x ∷ y ∷ [])) ∷ [])) →
+                valid (Ap Sum (Ap (Limit n) (b ∷ [ x ]) ∷ [ Ap (Limit n) (b ∷ [ y ]) ]))
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "LIMIT OF NEGATED VALUE IS NEGATED LIMIT"
+          ; function =
+            λ { (Ap (Limit n) (b ∷ (Ap Negate (x ∷ [])) ∷ [])) →
+                valid (Ap Negate [ Ap (Limit n) (b ∷ [ x ])])
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "LIMIT OF QUOTIENT IS QUOTIENT OF LIMITS"
+          ; function =
+            λ { (Ap (Limit n) (b ∷ Quotient x y coprime ∷ [])) →
+                valid (Quotient (Ap (Limit n) (b ∷ [ x ]))
+                                (Ap (Limit n) (b ∷ [ y ]))
+                                coprime)
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "LIMIT OF PRODUCT IS PRODUCT OF LIMITS"
+          ; function =
+            λ { (Ap (Limit n) (b ∷ Ap Product (x ∷ y ∷ []) ∷ [])) →
+                valid (Ap Product (Ap (Limit n) (b ∷ [ x ]) ∷ [ Ap (Limit n) (b ∷ [ y ])]))
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = {!!}
+          ; function =
+            λ { (Ap (Limit n1) (c ∷ Ap Exponent (Variable n2 ∷ NumberNatP x copr ∷ []) ∷ [])) →
+                if (n1 Data.String.== n2) ∧ (0 Data.Nat.<ᵇ x)
+                   then valid (Ap Exponent (c ∷ [ NumberNat x ]))
+                   else nothing
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "LAMBDA SUBSTITUTION"
+          ; function =
+            λ { (Ap (Lambda names) (body ∷ expressions)) →
+                valid (varSubstM (List.zip names (Data.Vec.toList expressions)) body)
+              ; _ → nothing}
+          }
+      ∷ record
+          { name = "DERIVATIVE REWRITING"
+          ; function = freeDerivativesFromPoints
+          }
+      ∷ record
+          { name = "CHAIN RULE FOR DERIVATIVES"
+          ; function = basicDerivativeChainRuleFunction
+          }
+      -- The naming of the following function could probably be improved.
+      -- Ideally, the function's name would be the name of the applied
+      -- simplification step, not just a simple "SIMPLIFY".
+      ∷ record
+          { name = "SIMPLIFY"
+          ; function = λ { (Ap f x) → [_,_] bust (valid ∘ Ap f) (updateFirst x)
+                         ; _ → nothing}
+          }
       ∷ []
-      )
       where
       bust = just ∘ inj₁
       valid = just ∘ inj₂
@@ -2547,13 +2704,24 @@ A bit informally, one can say that \AgdaFunction{composition-equality} proves th
             fDiff = Ap (Lambda List.[ n1 ]) ∘ (Ap (Derivative n1) [ Ap f x ] ∷_)
             x2 = Data.Vec.cast (trans fArity1 (sym eq)) x
         b _ = nothing
+\end{code}
 
+\subsection{Completing the Main Function}
+\AgdaFunction{main} is still the function which will eventually become \AgdaFunction{exceptionallyEvaluate}.  Basically, \AgdaFunction{main} tries all \AgdaFunction{rules} rules on the input and returns the first non-bogus or decidedly bogus output or, if no such value exists, will just output the input.
+
+\begin{code}
     {-# TERMINATING #-}
     main e = fromMaybe (inj₂ e)
-           $ List.head ∘ List.mapMaybe (_$ e)
-           $ Data.Vec.toList functions
+           $ List.head ∘ List.mapMaybe (λ rule → EvaluationRule.function rule e)
+           $ Data.Vec.toList rules
 
   {-# TERMINATING #-}
+\end{code}
+
+\subsection{Exporting}
+Once again, the author has chosen to permit using a nice shorthand.
+
+\begin{code}
   exceptionallyEvaluate = exceptionallyEvaluate.main
 \end{code}
 

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2219,8 +2219,19 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
           Data.Maybe.map (uncurry applyEquality) eq
         main = nothing
 
-      prodCommCheck : Check
-      prodCommCheck = {!!}
+      module prodCommCheck where
+        applyEquality :
+          {x y x' y' : ε} →
+          x ≡ x' →
+          y ≡ y' →
+          AlgebraicEquality (Ap Product (x ∷ y ∷ []))
+                            (Ap Product (y' ∷ x' ∷ []))
+        applyEquality refl refl = AlgebraicEquality.ProductCommutes
+
+        main : Check
+        main {Ap Product (a ∷ b ∷ [])} {Ap Product (c ∷ d ∷ [])} =
+          Data.Maybe.map (uncurry applyEquality) sumCommCheck.eq
+        main = nothing
 
       sumAssCheck : Check
       sumAssCheck = {!!}
@@ -2230,7 +2241,7 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
 
       main : Check
       main =   sumCommCheck.main
-           <∣> prodCommCheck
+           <∣> prodCommCheck.main
            <∣> sumAssCheck
            <∣> prodAssCheck
 

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2198,12 +2198,39 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
 
 \begin{code}
   module checkAlgebraicEquality where
+    module directCheck where
+      Check = {x y : ε} → Maybe (AlgebraicEquality x y)
+
+      sumCommCheck : Check
+      sumCommCheck = {!!}
+
+      prodCommCheck : Check
+      prodCommCheck = {!!}
+
+      sumAssCheck : Check
+      sumAssCheck = {!!}
+
+      prodAssCheck : Check
+      prodAssCheck = {!!}
+
+      main : Check
+      main =   sumCommCheck
+           <∣> prodCommCheck
+           <∣> sumAssCheck
+           <∣> prodAssCheck
+
+    module complexCheck where
+      main : {x y : ε} → ℕ → Exceptional (Maybe (AlgebraicEquality x y))
+      main = {!!}
+
     with-dec : {x y : ε} →
                ℕ →
                Dec (x ≡ y) →
                Exceptional (Maybe (AlgebraicEquality x y))
     with-dec iters = maybe (inj₂ ∘ just ∘ AlgebraicEquality.EqualityImpliesAE)
-                           {!!}
+                           (maybe′ (inj₂ ∘ just)
+                                   (complexCheck.main iters)
+                                   directCheck.main)
                    ∘ decToMaybe
 
     main : ℕ → (x y : ε) → Exceptional (Maybe (AlgebraicEquality x y))

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -1110,7 +1110,7 @@ record CAS {a : Level} (ε : Set a) : Set (Level.suc a) where
 For the purposes of this document, a verified computer algebra system is the combination of a \AgdaRecord{CAS} computer algebra system \(c\) \emph{and} some guarantees about \(c\).  The non-\AgdaRecord{CAS} parts of the combination are as follows:
 
 \begin{itemize}
- \item a proof which indicates that the algebraic equality relation is an equaivalence relation,
+ \item a proof which indicates that the algebraic equality relation is an equivalence relation,
  \item a proof which indicates that two values are structurally equivalent only if these same values are also algebraically equal,
  \item a proof which indicates that variables of different names are not definitely equal,
  \item a proof which indicates that for any two integers \(n_1\) and \(n_2\), the sum of the representations of \(n_1\) and \(n_2\) is the representation of \(n_1 + n_2\),
@@ -1148,10 +1148,10 @@ For the purposes of this document, a verified computer algebra system is the com
 \section{General Proofs regarding Equality}
 
 \subsection{The Proof of the Equivalence Nature of the Algebraic Equality Relation}
-A good CAS represents the complex numbers, whose equality relation is an equivalence relation.  Accordingly, a verified CAS's algebraic equality relation should be an equivalence relation.  \AgdaField{equality-is-equivance} values indicate that the algebraic equality relations actually are equivalence relations.
+A good CAS works with complex numbers, whose equality relation is an equivalence relation.  Accordingly, a verified CAS's algebraic equality relation should be an equivalence relation.  \AgdaField{equality-is-equivance} values indicate that the algebraic equality relations actually are equivalence relations.
 
 \subsection{The Structural-Equivalence-to-Algebraic-Equality Function}
-Also, in a good CAS, two expressions \(e_1\) and \(e_2\) are represented in the same way only if \(e_1\) is algebraically equal to \(e_2\).  This fact is represented through the use of \AgdaField{structural-equality-implies-definite-equality}.
+Also, in a good CAS, two expressions \(e_1\) and \(e_2\) are structurally equal only if \(e_1\) is algebraically equal to \(e_2\).  This fact is represented through the use of \AgdaField{VCAS.structural-equality-implies-definite-equality}.
 
 \section{General Proofs regarding Constants}
 

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -1508,7 +1508,7 @@ record VCAS {a : Level} {ε : Set a} (Cas : CAS ε) : Set a where
       (e : ε) →
       (count : ℕ) →
       IsConstant e →
-      ((Exceptional ε → Set) ∋ λ {(inj₂ x) → IsConstant x ; (inj₁ exc) → ⊤}) (rEvaluate count e)
+      ([_,_] (const ⊤) IsConstant) (rEvaluate count e)
 
     natural-less-than : (m n : ℕ) → m Data.Nat.< n → fromℕ m < fromℕ n
 \end{code}
@@ -2551,7 +2551,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = "DERIVATIVE OF X W.R.T. X IS 1"
+          { name = "DERIVATIVE OF X W.R.T. X"
           ; description = just
             "This rule is *also* kind of dubious, but, \
             \again, the behavior is like the behavior of Maxima."
@@ -2563,7 +2563,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = "DERIVATIVE OF RATIONAL IS 0"
+          { name = "DERIVATIVE OF RATIONAL"
           ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (NumberRat x ∷ [])) →
@@ -2571,7 +2571,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = "DERIVATIVE OF NEGATIVE IS NEGATIVE DERIVATIVE"
+          { name = "DERIVATIVE OF NEGATIVE"
           ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Negate x ∷ [])) →
@@ -2579,7 +2579,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = "DERIVATIVE OF SUM IS SUM OF DERIVATIVES"
+          { name = "DERIVATIVE OF SUM"
           ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Sum (x ∷ y ∷ []) ∷ [])) →
@@ -2588,7 +2588,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = "PRODUCT RULE FOR DERIVATIVES"
+          { name = "DERIVATIVE OF PRODUCT"
           ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Product (x ∷ y ∷ []) ∷ [])) →
@@ -2683,7 +2683,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = "LIMIT OF SUM IS SUM OF LIMITS"
+          { name = "LIMIT OF SUM"
           ; description = nothing
           ; function =
             λ { (Ap (Limit n) (b ∷ (Ap Sum (x ∷ y ∷ [])) ∷ [])) →
@@ -2691,7 +2691,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = "LIMIT OF NEGATED VALUE IS NEGATED LIMIT"
+          { name = "LIMIT OF NEGATED VALUE"
           ; description = nothing
           ; function =
             λ { (Ap (Limit n) (b ∷ (Ap Negate (x ∷ [])) ∷ [])) →
@@ -2699,7 +2699,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = "LIMIT OF QUOTIENT IS QUOTIENT OF LIMITS"
+          { name = "LIMIT OF QUOTIENT"
           ; description = nothing
           ; function =
             λ { (Ap (Limit n) (b ∷ Quotient x y coprime ∷ [])) →
@@ -2709,7 +2709,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = "LIMIT OF PRODUCT IS PRODUCT OF LIMITS"
+          { name = "LIMIT OF PRODUCT"
           ; description = nothing
           ; function =
             λ { (Ap (Limit n) (b ∷ Ap Product (x ∷ y ∷ []) ∷ [])) →
@@ -2759,9 +2759,8 @@ The bogus results may or may not indicate that the input expression is bogus.
       ... | yes eq = [_,_]′ inj₁ (λ xs → inj₂ (x ∷ xs)) (updateFirst xs)
       ... | no neq = [_,_]′ inj₁ (λ x → inj₂ (x ∷ xs)) (main x)
       recurseWithRule : EvaluationRule → EvaluationRule
-      recurseWithRule rule = record
-        { name = EvaluationRule.name rule
-        ; function =
+      recurseWithRule rule = record rule
+        { function =
           λ { (Ap f x) → [_,_] bust (valid ∘ Ap f) (updateFirst x)
             ; _ → nothing}
         }

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2332,7 +2332,7 @@ A value of type \AgdaFunction{main2} \AgdaBound{x} \AgdaBound{y} exists if and o
 According to \AgdaInductiveConstructor{EqualityImpliesAE}, two \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y} are structurally equal only if \AgdaBound{x} is algebraically equal to \AgdaBound{y}.
 
 \subsubsection{Commutativity}
-Basically, according to \AgdaInductiveConstructor{Commutativity}, if \AgdaBound{a} is a permutation of \AgdaBound{b} and \AgdaBound{f} is commutative, then \AgdaBound{f} \AgdaBound{a} is algebraically equivalent to \AgdaBound{f} \AgdaBound{b}.
+Basically, according to \AgdaInductiveConstructor{Commutativity}, if \AgdaBound{a} is a permutation of \AgdaBound{b}, and \AgdaBound{f} is commutative, then \AgdaBound{f} \AgdaBound{a} is algebraically equivalent to \AgdaBound{f} \AgdaBound{b}.
 
 \subsubsection{Associativity}
 Basically, according to \AgdaInductiveConstructor{Associativity}, if \AgdaBound{f} is associative and is of arity 2, then \(f\prime x \left(f y z\right) = f \left(f\prime x y\right) z\), where ``\(f'\)'' denotes the function which is represented by \AgdaBound{f}.

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2201,8 +2201,23 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
     module directCheck where
       Check = {x y : ε} → Maybe (AlgebraicEquality x y)
 
-      sumCommCheck : Check
-      sumCommCheck = {!!}
+      module sumCommCheck where
+        applyEquality : {x y x' y' : ε} →
+                        x ≡ x' →
+                        y ≡ y' →
+                        AlgebraicEquality (Ap Sum (x ∷ y ∷ []))
+                                          (Ap Sum (y' ∷ x' ∷ []))
+        applyEquality refl refl = AlgebraicEquality.SumCommutes
+
+        eq : {a b c d : ε} → Maybe ((a ≡ d) × (b ≡ c))
+        eq {a} {b} {c} {d} =
+          Data.Maybe.zip (decToMaybe (structuralEqualityOnε a d))
+                         (decToMaybe (structuralEqualityOnε b c))
+
+        main : Check
+        main {Ap Sum (a ∷ b ∷ [])} {Ap Sum (c ∷ d ∷ [])} =
+          Data.Maybe.map (uncurry applyEquality) eq
+        main = nothing
 
       prodCommCheck : Check
       prodCommCheck = {!!}
@@ -2214,7 +2229,7 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
       prodAssCheck = {!!}
 
       main : Check
-      main =   sumCommCheck
+      main =   sumCommCheck.main
            <∣> prodCommCheck
            <∣> sumAssCheck
            <∣> prodAssCheck

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2292,14 +2292,31 @@ For all \AgdaDatatype{ε} values \AgdaBound{x} and \AgdaBound{y}, if some evalua
                Data.Maybe.map AlgebraicEquality.Symmetry (main {e2} {e1})
         main = nothing
 
-      prodAssCheck : Check
-      prodAssCheck = {!!}
+      module prodAssCheck where
+        applyEqualities :
+          {a b c a' b' c' : ε} →
+          a ≡ a' →
+          b ≡ b' →
+          c ≡ c' →
+          AlgebraicEquality (Ap Product (a ∷ Ap Product (b ∷ c ∷ []) ∷ []))
+                            (Ap Product (Ap Product (a' ∷ b' ∷ []) ∷ c' ∷ []))
+        applyEqualities refl refl refl = AlgebraicEquality.ProductIsAssociative
+
+        main : Check
+        main {Ap Product (a ∷ Ap Product (b ∷ c ∷ []) ∷ [])}
+             {Ap Product (Ap Product (x ∷ y ∷ []) ∷ z ∷ [])} =
+             Data.Maybe.map (λ (a , b , c) → applyEqualities a b c)
+                            (tri-eq {a} {b} {c} {x} {y} {z})
+        main e1@{Ap Product (Ap Product (x ∷ y ∷ []) ∷ z ∷ [])}
+             e2@{Ap Product (a ∷ Ap Product (b ∷ c ∷ []) ∷ [])} =
+               Data.Maybe.map AlgebraicEquality.Symmetry (main {e2} {e1})
+        main = nothing
 
       main : Check
       main =   sumCommCheck.main
            <∣> prodCommCheck.main
            <∣> sumAssCheck.main
-           <∣> prodAssCheck
+           <∣> prodAssCheck.main
 
     module complexCheck where
       main : {x y : ε} → ℕ → Exceptional (Maybe (AlgebraicEquality x y))

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2373,7 +2373,7 @@ A bit informally, one can say that \AgdaFunction{composition-equality} proves th
 \end{code}
 
 \subsection{The Evaluation Rule Type}
-\AgdaRecord{EvaluationRule} is the type of evaluation rules, i.e., computation strategies, which are used by \AgdaFunction{exceptionallyEvaluate}.  For a given \AgdaRecord{EvaluationRule} value \AgdaBound{r}, \AgdaField{EvaluationRule.name} \AgdaBound{r} and \AgdaField{EvaluationRule.function} \AgdaBound{r} are the name of \AgdaBound{r} and the method of applying \AgdaBound{r}, respectively.
+\AgdaRecord{EvaluationRule} is the type of evaluation rules, i.e., computation strategies, which are used by \AgdaFunction{exceptionallyEvaluate}.  For a given \AgdaRecord{EvaluationRule} value \AgdaBound{r}, \AgdaField{EvaluationRule.name} \AgdaBound{r} and \AgdaField{EvaluationRule.function} \AgdaBound{r} are the name of \AgdaBound{r} and the method of applying \AgdaBound{r}, respectively, whereas \AgdaField{EvaluationRule.description} \AgdaBound{r} is, optionally, a description of the \AgdaBound{r} evaluation strategy and can pertain to caveats, proofs, and other such good things.
 
 \subsubsection{The Function Field}
 For the function field, \AgdaInductiveConstructor{just} \AgdaOperator{\AgdaFunction{∘}} \AgdaInductiveConstructor{inj₂} values, \AgdaInductiveConstructor{just} \AgdaOperator{\AgdaFunction{∘}} \AgdaInductiveConstructor{inj₁} values, and \AgdaInductiveConstructor{nothing} values are the results of successful application, indicators of bogus results, and indicators of nonapplicability, respectively.
@@ -2384,6 +2384,7 @@ The bogus results may or may not indicate that the input expression is bogus.
     record EvaluationRule : Set where
       field
         name : String
+        description : Maybe String
         function : ε → Maybe (Exceptional ε)
 \end{code}
 
@@ -2394,24 +2395,28 @@ The bogus results may or may not indicate that the input expression is bogus.
     rules = List.concat (List.map ruleWithRecurse (Data.Vec.toList
       ( record
           { name = "DOUBLE NEGATION"
+          ; description = nothing
           ; function =
             λ { (Ap Negate (Ap Negate (x ∷ []) ∷ [])) → valid x
               ; _ → nothing}
           }
       ∷ record
           { name = "RATIONAL NEGATION"
+          ; description = nothing
           ; function =
             λ { (Ap Negate (NumberRat x ∷ [])) → valid (NumberRat (ℚ.0ℚ ℚ.- x))
               ; _ → nothing}
           }
       ∷ record
           { name = "0 + x = x"
+          ; description = nothing
           ; function =
             λ { (Ap Sum (NumberNatP 0 c ∷ x ∷ [])) → valid x
               ; _ → nothing}
           }
       ∷ record
           { name = "RATIONAL SUM"
+          ; description = nothing
           ; function =
             λ { (Ap Sum (NumberRat x ∷ NumberRat y ∷ [])) →
                 valid (NumberRat (x ℚ.+ y))
@@ -2419,6 +2424,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "RATIONAL PRODUCT"
+          ; description = nothing
           ; function =
             λ { (Ap Product (NumberRat x ∷ NumberRat y ∷ [])) →
                 valid (NumberRat (x ℚ.* y))
@@ -2426,6 +2432,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "NATURAL EXPONENT"
+          ; description = nothing
           ; function =
             λ { (Ap Exponent (NumberNatP x c1 ∷ NumberNatP y c2 ∷ [])) →
                 if (x Data.Nat.≡ᵇ 0) ∧ (y Data.Nat.≡ᵇ 0)
@@ -2435,6 +2442,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "RATIONAL EXPONENT OF NATURAL"
+          ; description = nothing
           ; function =
             λ { (Ap Exponent (NumberNatP 0 coprime ∷ NumberRat y ∷ [])) →
                 if y ℚ.≤ᵇ ℚ.0ℚ
@@ -2442,22 +2450,24 @@ The bogus results may or may not indicate that the input expression is bogus.
                    else nothing
               ; _ → nothing}
           }
-      -- The following "x^0" evaluation rule is a bit dubious; this rule
-      -- indicates that Variable x ^ fromℕ 0 is algebraically equal to
-      -- fromℕ 1.  However, Variable x *could* feasibly be defined as
-      -- being equal to fromℕ 0.
-      -- The current behavior parallels Maxima, though.
       ∷ record
           { name = "0 ^ x = 1"
+          ; description = just
+            "The following \"x^0\" evaluation rule is a bit dubious; this rule \
+            \indicates that Variable x ^ fromℕ 0 is algebraically equal to \
+            \fromℕ 1.  However, Variable x *could* feasibly be defined as \
+            \being equal to fromℕ 0.\n\
+            \The current behavior parallels Maxima, though."
           ; function =
             λ { (Ap Exponent (x ∷ NumberNatP 0 c ∷ [])) → valid (NumberNat 1)
               ; _ → nothing}
           }
-      -- The following "0^x" evaluation rule, like the "x^0" rule, is
-      -- kind of dubious.  This rule, too, mirrors the behavior of
-      -- Maxima, though.
       ∷ record
           { name = "0 ^ x"
+          ; description = just
+            "This evaluation rule, like the \"x^0\" rule, is \
+            \kind of dubious.  This rule, too, mirrors the behavior of \
+            \Maxima, though."
           ; function =
             λ { (Ap Exponent ((NumberNatP 0 c) ∷ e ∷ [])) →
                  let eq2 = Data.Sum.Properties.≡-dec Data.String._≟_
@@ -2474,14 +2484,15 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "x ^ 1 = x"
+          ; description = nothing
           ; function =
             λ { (Ap Exponent (x ∷ NumberNatP 1 c ∷ [])) → valid x
               ; _ → nothing}
           }
-      -- The following evaluation rule prevents becoming stuck in a
-      -- derivative evaluation loop.
       ∷ record
           { name = "DERIVATIVE LOOP PREVENTION"
+          ; description = just
+            "This rule prevents becoming stuck in a derivative evaluation loop."
           ; function =
             λ { (Ap (Lambda (n1 List.∷ List.[])) (Ap (Derivative n2) e1 ∷ e2 ∷ [])) →
                 [_,_]′ bust
@@ -2490,10 +2501,11 @@ The bogus results may or may not indicate that the input expression is bogus.
                        (main (Ap (Derivative n2) e1))
               ; _ → nothing}
           }
-      -- The following evaluation rule is *also* kind of dubious, but,
-      -- again, the behavior is like the behavior of Maxima.
       ∷ record
           { name = "DERIVATIVE OF X W.R.T. X IS 1"
+          ; description = just
+            "This rule is *also* kind of dubious, but, \
+            \again, the behavior is like the behavior of Maxima."
           ; function =
             λ { (Ap (Derivative v1) (Variable v2 ∷ [])) →
                 if v1 Data.String.== v2
@@ -2503,6 +2515,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE OF RATIONAL IS 0"
+          ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (NumberRat x ∷ [])) →
                 valid (NumberNat 0)
@@ -2510,6 +2523,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE OF NEGATIVE IS NEGATIVE DERIVATIVE"
+          ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Negate x ∷ [])) →
                 valid (Ap Negate [ Ap (Derivative v1) x ])
@@ -2517,6 +2531,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE OF SUM IS SUM OF DERIVATIVES"
+          ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Sum (x ∷ y ∷ []) ∷ [])) →
                 valid (Ap Sum ( Ap (Derivative v1) [ x ]
@@ -2525,6 +2540,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "PRODUCT RULE FOR DERIVATIVES"
+          ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Product (x ∷ y ∷ []) ∷ [])) →
                 valid (Ap Sum
@@ -2534,6 +2550,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE OF SINE"
+          ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Sin (Variable v2 ∷ []) ∷ [])) →
                 if v1 Data.String.== v2
@@ -2543,6 +2560,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE OF COSINE"
+          ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Cos (Variable v2 ∷ []) ∷ [])) →
                 if v1 Data.String.== v2
@@ -2552,6 +2570,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE OF TANGENT"
+          ; description = nothing
           ; function =
              λ { (Ap (Derivative v1) (Ap Tan (Variable v2 ∷ []) ∷ [])) →
                  if v1 Data.String.== v2
@@ -2561,6 +2580,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE OF COSECANT"
+          ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Csc (Variable v2 ∷ []) ∷ [])) →
                 if v1 Data.String.== v2
@@ -2572,6 +2592,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE OF SECANT"
+          ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Sec (Variable v2 ∷ []) ∷ [])) →
                 if v1 Data.String.== v2
@@ -2583,6 +2604,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE OF COTANGENT"
+          ; description = nothing
           ; function =
             λ { (Ap (Derivative v1) (Ap Cot (Variable v2 ∷ []) ∷ [])) →
                 if v1 Data.String.== v2
@@ -2595,6 +2617,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "LIMIT OF SAME VARIABLE"
+          ; description = nothing
           ; function =
             λ { (Ap (Limit n1) (b ∷ Variable n2 ∷ [])) →
                 if n1 Data.String.== n2
@@ -2604,6 +2627,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "LIMIT OF CONSTANT IS SAME CONSTANT"
+          ; description = nothing
           ; function =
             λ { (Ap (Limit n) (b ∷ e ∷ [])) →
                 if isYes (IsConstant? e) then valid e else nothing
@@ -2611,6 +2635,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "LIMIT OF SUM IS SUM OF LIMITS"
+          ; description = nothing
           ; function =
             λ { (Ap (Limit n) (b ∷ (Ap Sum (x ∷ y ∷ [])) ∷ [])) →
                 valid (Ap Sum (Ap (Limit n) (b ∷ [ x ]) ∷ [ Ap (Limit n) (b ∷ [ y ]) ]))
@@ -2618,6 +2643,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "LIMIT OF NEGATED VALUE IS NEGATED LIMIT"
+          ; description = nothing
           ; function =
             λ { (Ap (Limit n) (b ∷ (Ap Negate (x ∷ [])) ∷ [])) →
                 valid (Ap Negate [ Ap (Limit n) (b ∷ [ x ])])
@@ -2625,6 +2651,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "LIMIT OF QUOTIENT IS QUOTIENT OF LIMITS"
+          ; description = nothing
           ; function =
             λ { (Ap (Limit n) (b ∷ Quotient x y coprime ∷ [])) →
                 valid (Quotient (Ap (Limit n) (b ∷ [ x ]))
@@ -2634,6 +2661,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "LIMIT OF PRODUCT IS PRODUCT OF LIMITS"
+          ; description = nothing
           ; function =
             λ { (Ap (Limit n) (b ∷ Ap Product (x ∷ y ∷ []) ∷ [])) →
                 valid (Ap Product (Ap (Limit n) (b ∷ [ x ]) ∷ [ Ap (Limit n) (b ∷ [ y ])]))
@@ -2641,6 +2669,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = {!!}
+          ; description = nothing
           ; function =
             λ { (Ap (Limit n1) (c ∷ Ap Exponent (Variable n2 ∷ NumberNatP x copr ∷ []) ∷ [])) →
                 if (n1 Data.String.== n2) ∧ (0 Data.Nat.<ᵇ x)
@@ -2650,6 +2679,7 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "LAMBDA SUBSTITUTION"
+          ; description = nothing
           ; function =
             λ { (Ap (Lambda names) (body ∷ expressions)) →
                 valid (varSubstM (List.zip names (Data.Vec.toList expressions)) body)
@@ -2657,10 +2687,12 @@ The bogus results may or may not indicate that the input expression is bogus.
           }
       ∷ record
           { name = "DERIVATIVE REWRITING"
+          ; description = nothing
           ; function = freeDerivativesFromPoints
           }
       ∷ record
           { name = "CHAIN RULE FOR DERIVATIVES"
+          ; description = nothing
           ; function = basicDerivativeChainRuleFunction
           }
       ∷ [])))

--- a/Casanova.lagda.tex
+++ b/Casanova.lagda.tex
@@ -2668,7 +2668,7 @@ The bogus results may or may not indicate that the input expression is bogus.
               ; _ → nothing}
           }
       ∷ record
-          { name = {!!}
+          { name = "LIMIT OF \\(x^n\\), WHERE \\(n\\) IS A NATURAL NUMBER"
           ; description = nothing
           ; function =
             λ { (Ap (Limit n1) (c ∷ Ap Exponent (Variable n2 ∷ NumberNatP x copr ∷ []) ∷ [])) →


### PR DESCRIPTION
With this change, evaluation rules for `exceptionallyEvaluate` now must have names.